### PR TITLE
fix for extractNCode failing

### DIFF
--- a/lib/ut.js
+++ b/lib/ut.js
@@ -212,15 +212,19 @@ class utClass {
 		if (spos >= 0) {
 			let pos = spos + slen - snip;
 			let done = false;
+			let quote = 0;
 			let level = 0;
 			extract = start.substr(0, slen - snip);
 			while (!done) {
 				switch (body[pos]) {
+					case '"':
+						quote++;
+						break;
 					case open:
-						level++;
+					  if (0 === quote % 2) level++;
 						break;
 					case close:
-						level--;
+						if (0 === quote % 2) level--;
 						if (!level) done = true;
 						break;
 				}


### PR DESCRIPTION
fixed block function that incorrectly looked at open/close chars within quotes and as such fails to extract the intended code chunk.
