### PR TITLE
Fix reading of shorts

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -83,7 +83,8 @@ class Channel extends Model {
 					v = v.contents[0].videoRenderer;
 				}
 				if (s) {
-					s = s.content.reelItemRenderer;
+					if (s.content.reelItemRenderer) s = s.content.reelItemRenderer;
+					else s = s.content.shortsLockupViewModel;
 					if (!s) v = item.richItemRenderer.content.videoRenderer;
 				}
 				if (w && w.videoId) {
@@ -176,6 +177,30 @@ class Channel extends Model {
 						if (ts > this.latest) this.latest = ts;
 						found.push(video);
 					} catch (e) { this.debug(e); }
+			        } else if (s && s.entityId) {
+					const videoId = s.onTap && s.onTap.innertubeCommand && s.onTap.innertubeCommand.reelWatchEndpoint
+							&& s.onTap.innertubeCommand.reelWatchEndpoint.videoId;
+					const title = s.overlayMetadata && s.overlayMetadata.primaryText && s.overlayMetadata.primaryText.content;
+					const viewsString = s.overlayMetadata && s.overlayMetadata.secondaryText
+							&& s.overlayMetadata.secondaryText.content;
+					const views = ut.viewQ(viewsString);
+					// No durations given for shorts
+					if (videoId && title && viewsString) {
+						try {
+							this.quantity++;
+							let ts = 0;
+							const video = new Video(this.session, { id: videoId, published: ts });
+							video.title = title;
+							video.views = views;
+							video.viewsString = viewsString;
+							video.author = this.author;
+							video.channelId = this.id;
+							video.channelThumb = this.thumbnail;
+							video.country = this.country;
+							if (ts > this.latest) this.latest = ts;
+							found.push(video);
+						} catch (e) { this.debug(e); }
+					}
 				} else if (m) {
 					try {
 						this.more = m.continuationEndpoint.continuationCommand.token;


### PR DESCRIPTION
Recently, YouTube will sometimes serve shorts info in a thing called a `shortsLockupViewModel`. This code reads from it.

Please let me know if there's anything at all I could change